### PR TITLE
refactor: noexceptとconst

### DIFF
--- a/Source/ShidenCore/Private/ShidenCoreFunctionLibrary.cpp
+++ b/Source/ShidenCore/Private/ShidenCoreFunctionLibrary.cpp
@@ -17,7 +17,7 @@
 #include "Widgets/SWindow.h"
 #include "ShidenCommand.h"
 
-SHIDENCORE_API void UShidenCoreFunctionLibrary::CopyToClipboard(const FString Str)
+SHIDENCORE_API void UShidenCoreFunctionLibrary::CopyToClipboard(const FString& Str)
 {
 	FPlatformApplicationMisc::ClipboardCopy(*Str);
 }
@@ -27,7 +27,7 @@ SHIDENCORE_API void UShidenCoreFunctionLibrary::GetFromClipboard(FString& Dest)
 	FPlatformApplicationMisc::ClipboardPaste(Dest);
 }
 
-SHIDENCORE_API int32 UShidenCoreFunctionLibrary::GetParsedLength(const FString text)
+SHIDENCORE_API int32 UShidenCoreFunctionLibrary::GetParsedLength(const FString& text)
 {
 	FString resultText = text;
 
@@ -68,7 +68,7 @@ struct TextPosition
 	int32 ContentEnd;
 };
 
-SHIDENCORE_API FString UShidenCoreFunctionLibrary::GetCharactersWithParsedLength(const FString text, const int32& len)
+SHIDENCORE_API FString UShidenCoreFunctionLibrary::GetCharactersWithParsedLength(const FString& text, const int32& len)
 {
 	FString resultText = text;
 	int32 length = len;
@@ -166,7 +166,7 @@ SHIDENCORE_API void UShidenCoreFunctionLibrary::CallFunctionByName(UObject* targ
 	targetObject->CallFunctionByNameWithArguments(*cmd, _Null, nullptr, true);
 }
 
-SHIDENCORE_API bool UShidenCoreFunctionLibrary::SaveFileAsCsv(const FString DefaultFileName, const FString SaveText)
+SHIDENCORE_API bool UShidenCoreFunctionLibrary::SaveFileAsCsv(const FString& DefaultFileName, const FString& SaveText)
 {
 	// get window handle
 	void* windowHandle = nullptr;

--- a/Source/ShidenCore/Private/ShidenCoreFunctionLibrary.h
+++ b/Source/ShidenCore/Private/ShidenCoreFunctionLibrary.h
@@ -28,13 +28,13 @@ class SHIDENCORE_API UShidenCoreFunctionLibrary : public UBlueprintFunctionLibra
 
 public:
 	UFUNCTION(BlueprintCallable, Category = "Shiden Visual Novel|Utility")
-	static void CopyToClipboard(const FString Str);
+	static void CopyToClipboard(const FString& Str);
 
 	UFUNCTION(BlueprintCallable, Category = "Shiden Visual Novel|Utility")
 	static void GetFromClipboard(FString& Dest);
 
 	UFUNCTION(BlueprintCallable, Category = "Shiden Visual Novel|Utility")
-	static int32 GetParsedLength(const FString text);
+	static int32 GetParsedLength(const FString& text);
 
 	UFUNCTION(BlueprintCallable, Category = "Shiden Visual Novel|Utility")
 	static void CallFunctionByName(UObject* targetObject, const FString functionName, const FString parameters);
@@ -43,13 +43,13 @@ public:
 	static void LoadTextFile(FString& FileName, FString& FileData, bool& bSuccess);
 
 	UFUNCTION(BlueprintCallable, Category = "Shiden Visual Novel|Utility")
-	static bool SaveFileAsCsv(const FString DefaultFileName, const FString SaveText);
+	static bool SaveFileAsCsv(const FString& DefaultFileName, const FString& SaveText);
 
 	UFUNCTION(BlueprintCallable, Category = "Shiden Visual Novel|Utility")
 	static void ParseCsv(FString CsvText, TArray<FShidenCsvParsedRow>& CsvParsedRow);
 
 	UFUNCTION(BlueprintCallable, Category = "Shiden Visual Novel|Utility")
-	static FString GetCharactersWithParsedLength(const FString text, const int32& len);
+	static FString GetCharactersWithParsedLength(const FString& text, const int32& len);
 
 	UFUNCTION(BlueprintCallable, Category = "Shiden Visual Novel|Utility", meta = (Latent, WorldContext = "WorldContextObject", LatentInfo = "LatentInfo", Duration = "0.2", Keywords = "sleep"))
 	static void MultiThreadDelay(UObject* WorldContextObject, float Duration, struct FLatentActionInfo LatentInfo);

--- a/Source/ShidenCore/Private/ShidenLoadingAssetInfo.h
+++ b/Source/ShidenCore/Private/ShidenLoadingAssetInfo.h
@@ -17,7 +17,7 @@ public:
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Shiden Visual Novel|Internal")
 	FString ObjectPath;
 
-	bool operator==(const FShidenLoadingAssetInfo& that) const
+	bool operator==(const FShidenLoadingAssetInfo& that) const noexcept
 	{
 		return ObjectPath == that.ObjectPath;
 	}

--- a/Source/ShidenCore/Private/ShidenPreset.h
+++ b/Source/ShidenCore/Private/ShidenPreset.h
@@ -47,7 +47,7 @@ public:
 	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "Shiden Visual Novel|Command")
 	FString Arg10;
 
-	bool operator==(const FShidenPreset& that) const
+	bool operator==(const FShidenPreset& that) const noexcept
 	{
 		return CommandName == that.CommandName && PresetName == that.PresetName;
 	}

--- a/Source/ShidenCore/Private/ShidenProjectConfig.cpp
+++ b/Source/ShidenCore/Private/ShidenProjectConfig.cpp
@@ -14,7 +14,7 @@ SHIDENCORE_API UShidenProjectConfig::UShidenProjectConfig(const FObjectInitializ
 	};
 }
 
-SHIDENCORE_API void UShidenProjectConfig::AddScenarioPath(const FGuid scenarioId, const FString scenarioPath) {
+SHIDENCORE_API void UShidenProjectConfig::AddScenarioPath(const FGuid& scenarioId, const FString& scenarioPath) {
 	TObjectPtr <UShidenProjectConfig> ShidenProjectConfig = GetMutableDefault <UShidenProjectConfig>();
 	ShidenProjectConfig->ScenarioPaths.Add(scenarioId, scenarioPath);
 	ShidenProjectConfig->SaveConfig(CPF_Config, *ShidenProjectConfig->GetDefaultConfigFilename());

--- a/Source/ShidenCore/Private/ShidenProjectConfig.h
+++ b/Source/ShidenCore/Private/ShidenProjectConfig.h
@@ -33,7 +33,7 @@ public:
 	TArray<FSoftObjectPath> CommandDefinitions;
 
 	UFUNCTION(BlueprintCallable, Category = "Shiden Visual Novel|Config")
-	static void AddScenarioPath(const FGuid scenarioId, const FString scenarioPath);
+	static void AddScenarioPath(const FGuid& scenarioId, const FString& scenarioPath);
 
 	UFUNCTION(BlueprintCallable, Category = "Shiden Visual Novel|Config")
 	static void SetScenarioPaths(const TMap<FGuid, FString>& paths);


### PR DESCRIPTION
1. const FString&で十分な場面でconst FStringが使われている箇所が散見されました。
ただし修正作業中にBlueprintCallableであることから当該部分の修正がBPに影響してしまう可能性を考慮して作業を中断しました。
一応途中まで進めた部分まではコミットしてありますが、適宜はじいてください。

2. 演算子オーバーライドしている部分にnoexceptを追加しました。
例外が発生しないため追加しました。
他にも追加できそうな関数はいくつか見つけましたが、演算子のオーバーライドに比べて影響が極軽微なのでそちらは対応していません。