### PR TITLE
Ver.1.6.1

### DIFF
--- a/Shiden.uplugin
+++ b/Shiden.uplugin
@@ -1,7 +1,7 @@
 {
 	"FileVersion": 3,
 	"Version": 1,
-	"VersionName": "1.6.0",
+	"VersionName": "1.6.1",
 	"FriendlyName": "Shiden Visual Novel Editor",
 	"Description": "A simple visual novel editor",
 	"Category": "Visual Novel",

--- a/Source/ShidenCore/Private/Expression/ShidenExpressionEvaluator.cpp
+++ b/Source/ShidenCore/Private/Expression/ShidenExpressionEvaluator.cpp
@@ -1156,6 +1156,18 @@ bool FShidenExpressionEvaluator::TryApplyBinaryOperation(const FShidenExpression
 			return true;
 		}
 
+		// Validate shift amount (must be non-negative and less than bit width)
+		if (RightInt < 0)
+		{
+			ErrorMessage = TEXT("Shift amount must be non-negative");
+			return false;
+		}
+		if (RightInt >= 32)
+		{
+			ErrorMessage = TEXT("Shift amount must be less than 32 for int32");
+			return false;
+		}
+
 		if (Operator == TEXT("<<"))
 		{
 			OutResult = FShidenExpressionValue(LeftInt << RightInt);

--- a/Source/ShidenCore/Private/Expression/ShidenExpressionEvaluatorTests.cpp
+++ b/Source/ShidenCore/Private/Expression/ShidenExpressionEvaluatorTests.cpp
@@ -2201,6 +2201,32 @@ void ShidenExpressionEvaluatorEdgeCaseTest::GetTests(TArray<FString>& OutBeautif
 
 	OutBeautifiedNames.Add("MixedVector2And3_ShouldFail");
 	OutTestCommands.Add(FShidenExpressionTestParameters(TEXT("[1,2] + [1,2,3]"), TEXT(""), false).ToString());
+
+	// Shift operation boundary tests
+	OutBeautifiedNames.Add("LeftShiftNegativeAmount_ShouldFail");
+	OutTestCommands.Add(FShidenExpressionTestParameters(TEXT("5 << -1"), TEXT(""), false).ToString());
+
+	OutBeautifiedNames.Add("RightShiftNegativeAmount_ShouldFail");
+	OutTestCommands.Add(FShidenExpressionTestParameters(TEXT("5 >> -1"), TEXT(""), false).ToString());
+
+	OutBeautifiedNames.Add("LeftShiftOverBitWidth_ShouldFail");
+	OutTestCommands.Add(FShidenExpressionTestParameters(TEXT("5 << 32"), TEXT(""), false).ToString());
+
+	OutBeautifiedNames.Add("RightShiftOverBitWidth_ShouldFail");
+	OutTestCommands.Add(FShidenExpressionTestParameters(TEXT("5 >> 32"), TEXT(""), false).ToString());
+
+	OutBeautifiedNames.Add("LeftShiftLargeAmount_ShouldFail");
+	OutTestCommands.Add(FShidenExpressionTestParameters(TEXT("1 << 100"), TEXT(""), false).ToString());
+
+	OutBeautifiedNames.Add("RightShiftLargeAmount_ShouldFail");
+	OutTestCommands.Add(FShidenExpressionTestParameters(TEXT("1 >> 100"), TEXT(""), false).ToString());
+
+	// Edge cases: shift by 31 (maximum valid shift for int32) should succeed
+	OutBeautifiedNames.Add("LeftShift_MaxValidAmount");
+	OutTestCommands.Add(FShidenExpressionTestParameters(TEXT("1 << 31"), TEXT("-2147483648")).ToString());
+
+	OutBeautifiedNames.Add("RightShift_MaxValidAmount");
+	OutTestCommands.Add(FShidenExpressionTestParameters(TEXT("-2147483648 >> 31"), TEXT("-1")).ToString());
 }
 
 bool ShidenExpressionEvaluatorEdgeCaseTest::RunTest(const FString& Parameters)

--- a/Source/ShidenCore/Public/Expression/ShidenExpressionBlueprintLibrary.h
+++ b/Source/ShidenCore/Public/Expression/ShidenExpressionBlueprintLibrary.h
@@ -87,12 +87,23 @@ public:
 	/**
 	 * Validates an expression without evaluating it.
 	 *
+	 * @param ProcessName The process name (use "Default" if unsure)
 	 * @param Expression The expression to validate
 	 * @param ErrorMessage [out] Error message if validation failed
 	 * @return True if the expression is valid
 	 */
-	UFUNCTION(BlueprintCallable, Category = "Shiden Visual Novel|Expression", meta = (DisplayName = "Validate Expression"))
-	static UPARAM(DisplayName = "Success") bool TryValidateExpression(const FString& Expression, FString& ErrorMessage);
+	UFUNCTION(BlueprintCallable, Category = "Shiden Visual Novel|Expression", meta = (ProcessName = "Default", DisplayName = "Validate Expression"))
+	static UPARAM(DisplayName = "Success") bool TryValidateExpression(const FString& ProcessName, const FString& Expression, FString& ErrorMessage);
+
+	/**
+	 * Validates an expression without evaluating it and without variable substitution.
+	 *
+	 * @param Expression The expression to validate
+	 * @param ErrorMessage [out] Error message if validation failed
+	 * @return True if the expression is valid
+	 */
+	UFUNCTION(BlueprintCallable, Category = "Shiden Visual Novel|Expression", meta = (DisplayName = "Validate Expression Raw"))
+	static UPARAM(DisplayName = "Success") bool TryValidateExpressionRaw(const FString& Expression, FString& ErrorMessage);
 
 	/**
 	 * Evaluates an expression and returns an integer result without variable substitution.
@@ -164,4 +175,6 @@ private:
 	static FString ReplaceVariablesInExpression(const FString& ProcessName, const FString& Expression);
 
 	static bool TryCreateScopeKey(const FString& ProcessName, FString& ScenarioKey);
+
+	static FString EscapeStringForExpression(const FString& StringValue);
 };


### PR DESCRIPTION
## 概要
- 仕様変更
    -  UShidenExpressionBlueprintLibrary の TryValidateExpression に ProcessName 引数を追加
    - UShidenExpressionBlueprintLibrary に TryValidateExpressionRaw 関数を追加
- 不具合修正
    - UShidenExpressionBlueprintLibrary で、変数の値が正しくエスケープされていない不具合を修正
    - シフト演算のバリデーションを追加

## Overview

- Specification Changes
    - Added a ProcessName parameter to TryValidateExpression in UShidenExpressionBlueprintLibrary
    - Added a TryValidateExpressionRaw function to UShidenExpressionBlueprintLibrary
- Bug Fixes
    - Fixed an issue in UShidenExpressionBlueprintLibrary where variable values were not correctly escaped
    - Added validation for shift operations