### PR TITLE
Fix material parameter loss on load by ordering RestoreFromSaveData

### DIFF
--- a/Source/ShidenCore/Private/Scenario/ShidenScenarioBlueprintLibrary.cpp
+++ b/Source/ShidenCore/Private/Scenario/ShidenScenarioBlueprintLibrary.cpp
@@ -796,6 +796,21 @@ bool UShidenScenarioBlueprintLibrary::TryInitFromSaveData(UShidenWidget* ShidenW
 		UShidenBlueprintLibrary::InitCommandDefinitions();
 	}
 
+	// Resolve every command object first so we can order the restore calls by priority.
+	// Some commands depend on the result of another command's restore (for example, the material
+	// parameter commands operate on a dynamic material created from the brush set by the Image
+	// command). The raw iteration order of ScenarioProperties depends on which command type was
+	// registered first during play, so without explicit ordering the restore result is non-deterministic.
+	struct FRestoreEntry
+	{
+		const FShidenScenarioProperties* Properties;
+		UShidenCommandObject* CommandObject;
+		int32 Priority;
+	};
+
+	TArray<FRestoreEntry> RestoreEntries;
+	RestoreEntries.Reserve(ShidenSubsystem->ScenarioProperties.Num());
+
 	for (const auto& [CommandName, ScenarioProperties] : ShidenSubsystem->ScenarioProperties)
 	{
 		const FShidenCommandDefinition* CommandDef = ShidenSubsystem->CommandDefinitionCache.Find(CommandName);
@@ -813,8 +828,20 @@ bool UShidenScenarioBlueprintLibrary::TryInitFromSaveData(UShidenWidget* ShidenW
 				TEXT("Failed to get command '%s'. Please check project config and command definitions."), *CommandName);
 			return false;
 		}
+
+		RestoreEntries.Add(FRestoreEntry{&ScenarioProperties, CommandObject, CommandObject->GetRestoreFromSaveDataPriority()});
+	}
+
+	// Stable sort keeps the original insertion order for commands of equal priority.
+	RestoreEntries.StableSort([](const FRestoreEntry& A, const FRestoreEntry& B)
+	{
+		return A.Priority < B.Priority;
+	});
+
+	for (const FRestoreEntry& Entry : RestoreEntries)
+	{
 		EShidenInitFromSaveDataStatus Status = EShidenInitFromSaveDataStatus::Complete;
-		CommandObject->RestoreFromSaveData(ScenarioProperties.ScenarioProperties, ShidenWidget, ShidenManager, CallerObject, Status, ErrorMessage);
+		Entry.CommandObject->RestoreFromSaveData(Entry.Properties->ScenarioProperties, ShidenWidget, ShidenManager, CallerObject, Status, ErrorMessage);
 		if (Status == EShidenInitFromSaveDataStatus::Error)
 		{
 			return false;

--- a/Source/ShidenCore/Public/Command/Implementations/ShidenChangeMaterialScalarParameterCommand.h
+++ b/Source/ShidenCore/Public/Command/Implementations/ShidenChangeMaterialScalarParameterCommand.h
@@ -29,6 +29,10 @@ class SHIDENCORE_API UShidenChangeMaterialScalarParameterCommand : public UShide
 	                                                const TScriptInterface<IShidenManagerInterface>& ShidenManager,
 	                                                UObject* CallerObject, EShidenInitFromSaveDataStatus& Status, FString& ErrorMessage) override;
 
+	// Restore after brush-setting commands (e.g. Image), since this operates on a dynamic material
+	// created from the target's brush. See GetRestoreFromSaveDataPriority in the base class.
+	virtual int32 GetRestoreFromSaveDataPriority() const override { return 100; }
+
 	virtual void PreProcessCommand_Implementation(const FString& ProcessName, const FShidenCommand& Command, UShidenWidget* ShidenWidget,
 	                                              const TScriptInterface<IShidenManagerInterface>& ShidenManager,
 	                                              UObject* CallerObject, EShidenPreProcessStatus& Status, FString& ErrorMessage) override;

--- a/Source/ShidenCore/Public/Command/Implementations/ShidenChangeMaterialTextureParameterCommand.h
+++ b/Source/ShidenCore/Public/Command/Implementations/ShidenChangeMaterialTextureParameterCommand.h
@@ -25,6 +25,10 @@ class SHIDENCORE_API UShidenChangeMaterialTextureParameterCommand : public UShid
 	                                                const TScriptInterface<IShidenManagerInterface>& ShidenManager,
 	                                                UObject* CallerObject, EShidenInitFromSaveDataStatus& Status, FString& ErrorMessage) override;
 
+	// Restore after brush-setting commands (e.g. Image), since this operates on a dynamic material
+	// created from the target's brush. See GetRestoreFromSaveDataPriority in the base class.
+	virtual int32 GetRestoreFromSaveDataPriority() const override { return 100; }
+
 	virtual void ProcessCommand_Implementation(const FString& ProcessName, const FShidenCommand& Command, UShidenWidget* ShidenWidget,
 	                                           const TScriptInterface<IShidenManagerInterface>& ShidenManager,
 	                                           const float DeltaTime, UObject* CallerObject, EShidenProcessStatus& Status, FString& BreakReason,

--- a/Source/ShidenCore/Public/Command/ShidenCommandObject.h
+++ b/Source/ShidenCore/Public/Command/ShidenCommandObject.h
@@ -64,6 +64,18 @@ public:
 	                                                EShidenInitFromSaveDataStatus& Status, FString& ErrorMessage);
 
 	/**
+	 * Returns the priority used to order RestoreFromSaveData calls when loading a save game.
+	 * Commands are restored in ascending priority order (lower values restore first).
+	 * Commands whose restore depends on the result of another command's restore should return a
+	 * higher value so they run later. For example, the material parameter commands operate on a
+	 * dynamic material created from the brush set by the Image command, so they must restore after
+	 * Image; otherwise SetBrushFromAsset would discard the dynamic material and lose the parameter.
+	 * Commands with equal priority keep their original (insertion) order.
+	 * @return Restore order priority (default 0)
+	 */
+	virtual int32 GetRestoreFromSaveDataPriority() const { return 0; }
+
+	/**
 	 * Previews a command in editor.
 	 * @param Command The command to preview
 	 * @param ShidenWidget The Shiden widget instance


### PR DESCRIPTION
## Summary

`ChangeMaterialTextureParameter` and `ChangeMaterialScalarParameter` set a value on a **dynamic material instance** obtained from the target's brush (`UImage::GetDynamicMaterial()` / `URetainerBox::GetEffectMaterial()`). The `Image` command's `RestoreFromSaveData` calls `SetBrushFromAsset`, which replaces the brush and **discards that dynamic material**.

On load, `UShidenScenarioBlueprintLibrary::TryInitFromSaveData` iterated `ShidenSubsystem->ScenarioProperties` in raw `TMap` order. That map is keyed by command name and ordered by *which command type was first registered during play*. When a material-parameter command's entry happened to come **before** the `Image` entry, the parameter was applied to a dynamic material that the later `Image` restore then discarded — so the change was silently lost on save/load. Because the order depends on play history, the bug is intermittent (it reproduces only for some save data).

This was originally found with `ChangeMaterialTextureParameter` on an `Image` target; `ChangeMaterialScalarParameter` has the same dependency.

## Fix

Make the restore order explicit instead of relying on `TMap` iteration order:

- Add `virtual int32 GetRestoreFromSaveDataPriority() const` to `UShidenCommandObject` (default `0`). Commands are restored in ascending priority order; commands whose restore depends on another command's restore return a higher value.
- Override it to `100` in `UShidenChangeMaterialTextureParameterCommand` and `UShidenChangeMaterialScalarParameterCommand` so they restore **after** brush-setting commands such as `Image`.
- `TryInitFromSaveData` now resolves all command objects, **stable-sorts** them by priority, then restores. The stable sort preserves the previous order for equal-priority commands, so behavior is unchanged except for the intended reordering.

## Notes

- No public/serialized data changes; existing save files load correctly.
- `RetainerBox` targets were not directly affected (no `SetBrushFromAsset`), but routing them through the same priority keeps the ordering consistent and future-proof.